### PR TITLE
fix `transformers` import

### DIFF
--- a/networks/med.py
+++ b/networks/med.py
@@ -36,12 +36,14 @@ from transformers.modeling_outputs import (
     SequenceClassifierOutput,
     TokenClassifierOutput,
 )
-from transformers.modeling_utils import (
-    PreTrainedModel,
+from transformers.modeling_utils import PreTrainedModel
+
+from transformers.pytorch_utils import (
     apply_chunking_to_forward,
     find_pruneable_heads_and_indices,
     prune_linear_layer,
 )
+
 from transformers.utils import logging
 from transformers.models.bert.configuration_bert import BertConfig
 

--- a/networks/nlvr_encoder.py
+++ b/networks/nlvr_encoder.py
@@ -26,12 +26,14 @@ from transformers.modeling_outputs import (
     SequenceClassifierOutput,
     TokenClassifierOutput,
 )
-from transformers.modeling_utils import (
-    PreTrainedModel,
+from transformers.modeling_utils import PreTrainedModel
+
+from transformers.pytorch_utils import (
     apply_chunking_to_forward,
     find_pruneable_heads_and_indices,
     prune_linear_layer,
 )
+
 from transformers.utils import logging
 from transformers.models.bert.configuration_bert import BertConfig
 


### PR DESCRIPTION
According to `transformers` library [codebase](https://github.com/huggingface/transformers/blob/main/src/transformers/pytorch_utils.py), `apply_chunking_to_forward`, `find_pruneable_heads_and_indices`, and `prune_linear_layer` were moved to `pytorch_utils`.

This PR fixes the incorrect imports.